### PR TITLE
Fix if/unless modifiers

### DIFF
--- a/c_src/nif.cc
+++ b/c_src/nif.cc
@@ -39,6 +39,7 @@ extern "C"
       {"new_bool_var_nif", 2, new_bool_var_nif},
       {"new_builder_nif", 0, new_builder_nif},
       {"new_int_var_nif", 4, new_int_var_nif},
+      {"only_enforce_if_nif", 2, only_enforce_if_nif},
       {"solution_bool_value_nif", 2, solution_bool_value_nif},
       {"solution_integer_value_nif", 2, solution_integer_value_nif},
       {"solve_nif", 1, solve_nif},

--- a/test/exhort/sat/builder_test.exs
+++ b/test/exhort/sat/builder_test.exs
@@ -136,7 +136,7 @@ defmodule Exhort.SAT.BuilderTest do
       |> Builder.def_int_var(:y, {0, 10})
       |> Builder.def_bool_var(:b)
       |> Builder.constrain(:x, :>=, 5, if: :b)
-      |> Builder.constrain(:x, :<=, 5, unless: :b)
+      |> Builder.constrain(:x, :<, 5, unless: :b)
       |> Builder.constrain(LinearExpression.sum(:x, :y), :==, 10, if: :b)
       |> Builder.constrain(:y, :==, 0, unless: :b)
 
@@ -152,7 +152,7 @@ defmodule Exhort.SAT.BuilderTest do
     assert 10 == SolverResponse.int_val(response, :x)
     assert 0 == SolverResponse.int_val(response, :y)
     assert SolverResponse.bool_val(response, :b)
-    assert 2 == acc
+    assert 11 == acc
   end
 
   test "zebra" do


### PR DESCRIPTION
Was not in the list of NIFs.

Maybe all the functions in `Nif` should `raise`.