### PR TITLE
Add N-Queens sample and use exprs for `all!=`

### DIFF
--- a/c_src/cp_model_builder.cc
+++ b/c_src/cp_model_builder.cc
@@ -603,7 +603,7 @@ extern "C"
       return enif_make_badarg(env);
     }
 
-    std::vector<IntVar> vars;
+    std::vector<LinearExpr> vars;
     ERL_NIF_TERM head;
     ERL_NIF_TERM tail;
     ERL_NIF_TERM current = argv[1];
@@ -614,8 +614,8 @@ extern "C"
         return enif_make_badarg(env);
       }
 
-      IntVarWrapper *var;
-      if (!get_int_var(env, head, &var))
+      LinearExprWrapper *var;
+      if (!get_linear_expression(env, head, &var))
       {
         return enif_make_badarg(env);
       }

--- a/lib/exhort/sat/builder.ex
+++ b/lib/exhort/sat/builder.ex
@@ -397,6 +397,7 @@ defmodule Exhort.SAT.Builder do
           builder |> add_abs_equal(Vars.get(vars, lhs), Vars.get(vars, rhs)) |> modify(opts, vars)
 
         {:"all!=", list, opts} ->
+          list = Enum.map(list, &LinearExpression.resolve(&1, vars))
           builder |> add_all_different(list) |> modify(opts, vars)
 
         {:no_overlap, list, opts} ->
@@ -492,10 +493,7 @@ defmodule Exhort.SAT.Builder do
 
   defp add_all_different(%Builder{res: builder_res, vars: vars} = _builder, list) do
     list
-    |> Enum.map(fn var ->
-      Vars.get(vars, var)
-      |> then(& &1.res)
-    end)
+    |> Enum.map(& &1.res)
     |> then(fn var_list ->
       Nif.add_all_different_nif(builder_res, var_list)
     end)

--- a/lib/exhort/sat/linear_expression.ex
+++ b/lib/exhort/sat/linear_expression.ex
@@ -154,14 +154,16 @@ defmodule Exhort.SAT.LinearExpression do
 
   def resolve(%LinearExpression{} = expr, _vars), do: expr
 
-  def resolve(%BoolVar{} = var, _vars) do
+  def resolve(%BoolVar{} = var, vars) do
     var
+    |> then(&Vars.get(vars, &1))
     |> then(&Nif.expr_from_bool_var_nif(&1.res))
     |> then(&%LinearExpression{res: &1, expr: var})
   end
 
-  def resolve(%IntVar{} = var, _vars) do
+  def resolve(%IntVar{} = var, vars) do
     var
+    |> then(&Vars.get(vars, &1))
     |> then(&Nif.expr_from_int_var_nif(&1.res))
     |> then(&%LinearExpression{res: &1, expr: var})
   end

--- a/lib/exhort/sat/vars.ex
+++ b/lib/exhort/sat/vars.ex
@@ -23,7 +23,9 @@ defmodule Exhort.SAT.Vars do
   @doc """
   Get a variable by name.
   """
-  @spec get(Vars.t(), name :: atom() | String.t()) :: nil | any()
+  @spec get(Vars.t(), name :: atom() | String.t() | map()) :: nil | any()
+  def get(%Vars{map: map} = vars, %{name: name}), do: get(vars, name)
+
   def get(%Vars{map: map} = _vars, name) do
     case Map.get(map, name) do
       nil -> raise "Undefined variable: #{inspect(name)}"

--- a/test/samples/exhort/sat/n_queens_test.exs
+++ b/test/samples/exhort/sat/n_queens_test.exs
@@ -1,0 +1,54 @@
+defmodule Samples.Exhort.SAT.NQueens do
+  use ExUnit.Case
+  use Exhort.SAT.Builder
+
+  test "n-queens" do
+    board_size = 4
+    columns = 0..(board_size - 1)
+
+    acc = %{
+      builder: Builder.new(),
+      queens: []
+    }
+
+    %{
+      builder: builder,
+      queens: queens
+    } =
+      Enum.reduce(columns, acc, fn column, %{builder: builder, queens: queens} = acc ->
+        queen = "queen_#{column}"
+        queens = queens ++ [queen]
+
+        builder =
+          builder
+          |> Builder.def_int_var(^queen, {0, board_size - 1})
+          |> Builder.def_constant("#{column}", column)
+
+        %{acc | builder: builder, queens: queens}
+      end)
+
+    builder = Builder.constrain_list(builder, :"all!=", queens)
+
+    builder =
+      Enum.reduce(columns, [], fn column, constraints = _acc ->
+        queen = Map.get(builder.vars.map, "queen_#{column}")
+        desc_diagonal = LinearExpression.sum(column, queen)
+        constraints ++ [desc_diagonal]
+      end)
+      |> then(&Builder.constrain_list(builder, :"all!=", &1))
+
+    builder =
+      Enum.reduce(columns, [], fn column, constraints = _acc ->
+        queen = Map.get(builder.vars.map, "queen_#{column}")
+        asc_diagonal = LinearExpression.minus(column, queen)
+        constraints ++ [asc_diagonal]
+      end)
+      |> then(&Builder.constrain_list(builder, :"all!=", &1))
+
+    assert :optimal ==
+             builder
+             |> Builder.build()
+             |> Model.solve()
+             |> then(& &1.status)
+  end
+end


### PR DESCRIPTION
`all!=` previously only worked with lists of integer variables. This updates it to work with lists of linear expressions and handles any necessary conversions prior to invoking the NIF. Also adds the N-Queens sample, which tests this update directly.