### PR TITLE
Support adding list of items to builder

### DIFF
--- a/lib/exhort/sat/bool_var.ex
+++ b/lib/exhort/sat/bool_var.ex
@@ -3,6 +3,13 @@ defmodule Exhort.SAT.BoolVar do
   A boolean variable defined in the model.
   """
 
+  alias __MODULE__
+
   @type t :: %__MODULE__{}
   defstruct [:res, :name]
+
+  @spec new(name :: String.t()) :: BoolVar.t()
+  def new(name) do
+    %BoolVar{name: name}
+  end
 end

--- a/lib/exhort/sat/bool_var.ex
+++ b/lib/exhort/sat/bool_var.ex
@@ -8,6 +8,14 @@ defmodule Exhort.SAT.BoolVar do
   @type t :: %__MODULE__{}
   defstruct [:res, :name]
 
+  @doc """
+  Define a new boolean variable. In the model, true and false are represented as
+  1 and 0, respectively.
+
+  - `name` - The variable name that may be referenced in other expressions.
+  - `domain` - The upper and lower bounds of the variable defined as a tuple,
+    `{lower_bound, upper_bound}`.
+  """
   @spec new(name :: String.t()) :: BoolVar.t()
   def new(name) do
     %BoolVar{name: name}

--- a/lib/exhort/sat/builder.ex
+++ b/lib/exhort/sat/builder.ex
@@ -26,12 +26,16 @@ defmodule Exhort.SAT.Builder do
 
   defmacro __using__(_options) do
     quote do
+      alias Exhort.SAT.BoolVar
       alias Exhort.SAT.Builder
+      alias Exhort.SAT.Constraint
+      alias Exhort.SAT.IntVar
       alias Exhort.SAT.LinearExpression
       alias Exhort.SAT.Model
       alias Exhort.SAT.SolverResponse
 
       require Exhort.SAT.Builder
+      require Exhort.SAT.Constraint
       require Exhort.SAT.LinearExpression
       require Exhort.SAT.SolverResponse
     end
@@ -46,6 +50,26 @@ defmodule Exhort.SAT.Builder do
   @spec new() :: Builder.t()
   def new do
     %Builder{}
+  end
+
+  @doc """
+  Add an item or list of items to the builder.
+  """
+  @spec add(Builder.t(), list() | BoolVar.t() | IntVar.t() | Constraint.t()) :: Builder.t()
+  def add(builder, list) when is_list(list) do
+    Enum.reduce(list, builder, &add(&2, &1))
+  end
+
+  def add(%Builder{vars: vars} = builder, %BoolVar{} = var) do
+    %Builder{builder | vars: Vars.add(vars, var)}
+  end
+
+  def add(%Builder{vars: vars} = builder, %IntVar{} = var) do
+    %Builder{builder | vars: Vars.add(vars, var)}
+  end
+
+  def add(%Builder{constraints: constraints} = builder, %Constraint{defn: defn}) do
+    %Builder{builder | constraints: constraints ++ [defn]}
   end
 
   @doc """

--- a/lib/exhort/sat/constraint.ex
+++ b/lib/exhort/sat/constraint.ex
@@ -13,6 +13,55 @@ defmodule Exhort.SAT.Constraint do
   ```
   :"all!=" | :no_overlap
   ```
+
+  The expression must include a boundary: `<`, `<=`, `==`, `>=`, `>`.
+
+  ```
+  x < y
+  ```
+
+  The components of the expressoin may be simple mathematical expressions,
+  including the use of `+` and `*`:
+
+  ```
+  x * y = z
+  ```
+
+  The `sum/1` function may be used to sum over a series of terms:
+
+  ```
+  sum(x + y) == z
+  ```
+
+  The variables in the expression are defined in the model and do not by default
+  reference the variables in Elixir scope. The pin operator, `^` may be used to
+  reference a scoped Elixir variable.
+
+  For example, where `x` is a model variable (e.g., `def_int_var(x, {0, 3}`))
+  and `y` is an Elixir variable (e.g., `y = 2`):
+
+  ```
+  x < ^y
+  ```
+
+  A `for` comprehension may be used to generate list values:
+
+  ```
+  sum(for {x, y} <- ^list, do: x * y) == z
+  ```
+
+  As a larger example:
+
+  ```
+  y = 20
+  z = [{0, 1}, {2, 3}, {4, 5}]
+
+  Builder.new()
+  |> Builder.def_int_var(x, {0, 3})
+  |> Builder.constrain(sum(for {a, b} <- ^z, do: ^a * ^b) < y)
+  |> Builder.build()
+  ...
+  ```
   """
 
   alias Exhort.SAT.DSL
@@ -23,6 +72,9 @@ defmodule Exhort.SAT.Constraint do
   @type t :: %__MODULE__{}
   defstruct [:res, :defn]
 
+  @doc """
+  Define a bounded constraint.
+  """
   defmacro new(expr, opts \\ []) do
     expr =
       case expr do

--- a/lib/exhort/sat/constraint.ex
+++ b/lib/exhort/sat/constraint.ex
@@ -14,8 +14,32 @@ defmodule Exhort.SAT.Constraint do
   :"all!=" | :no_overlap
   ```
   """
+
+  alias Exhort.SAT.DSL
+  alias __MODULE__
+
   @type constraint :: :< | :<= | :== | :>= | :> | :"abs==" | :"all!=" | :no_overlap
 
   @type t :: %__MODULE__{}
   defstruct [:res, :defn]
+
+  defmacro new(expr, opts \\ []) do
+    expr =
+      case expr do
+        {:==, m1, [lhs, {:abs, _m2, [var]}]} ->
+          {:"abs==", m1, [lhs, var]}
+
+        expr ->
+          expr
+      end
+
+    {op, _, [lhs, rhs]} = expr
+    lhs = DSL.transform_expression(lhs)
+    rhs = DSL.transform_expression(rhs)
+    opts = Enum.map(opts, &DSL.transform_expression(&1))
+
+    quote do
+      %Constraint{defn: {unquote(lhs), unquote(op), unquote(rhs), unquote(opts)}}
+    end
+  end
 end

--- a/lib/exhort/sat/int_var.ex
+++ b/lib/exhort/sat/int_var.ex
@@ -3,6 +3,14 @@ defmodule Exhort.SAT.IntVar do
   An integer variable defined in the model.
   """
 
+  alias __MODULE__
+
   @type t :: %__MODULE__{}
   defstruct [:res, :name, :domain]
+
+  @spec new(name :: String.t(), domain :: {lower_bound :: integer(), upper_bound :: integer()}) ::
+          IntVar.t()
+  def new(name, domain) do
+    %IntVar{name: name, domain: domain}
+  end
 end

--- a/lib/exhort/sat/int_var.ex
+++ b/lib/exhort/sat/int_var.ex
@@ -8,6 +8,13 @@ defmodule Exhort.SAT.IntVar do
   @type t :: %__MODULE__{}
   defstruct [:res, :name, :domain]
 
+  @doc """
+  Define a new integer variable.
+
+  - `name` - The variable name that may be referenced in other expressions.
+  - `domain` - The upper and lower bounds of the variable defined as a tuple,
+    `{lower_bound, upper_bound}`.
+  """
   @spec new(name :: String.t(), domain :: {lower_bound :: integer(), upper_bound :: integer()}) ::
           IntVar.t()
   def new(name, domain) do

--- a/lib/exhort/sat/interval_var.ex
+++ b/lib/exhort/sat/interval_var.ex
@@ -3,6 +3,22 @@ defmodule Exhort.SAT.IntervalVar do
   An interval variable defined in the model.
   """
 
+  alias __MODULE__
+
   @type t :: %__MODULE__{}
   defstruct [:res, :name, :start, :size, :stop]
+
+  @doc """
+  Define a new interval variable.
+
+  - `name` - The variable name that may be referenced in other expressions.
+  - `start` - The lower bound of the interval
+  - `size` - The step size of the parts of the iterval
+  - `stop` - The upper bound of the interval
+  """
+  @spec new(name :: String.t(), start :: integer(), size :: integer(), stop :: integer()) ::
+          IntervalVar.t()
+  def new(name, start, size, stop) do
+    %IntervalVar{name: name, start: start, size: size, stop: stop}
+  end
 end

--- a/lib/exhort/sat/linear_expression.ex
+++ b/lib/exhort/sat/linear_expression.ex
@@ -3,6 +3,9 @@ defmodule Exhort.SAT.LinearExpression do
   An expression in terms of variables and operators, constraining the overall
   model.
 
+  Expressions should be defined through `Exhort.SAT.Constraint` or
+  `Exhort.SAT.Builder`.
+
   The approach here is to transform values into `LinearExpression`s and then
   apply the operator (e.g., `:sum`) to the expressions. This allows for fewer
   NIF functions do the combination of the number of arguments.


### PR DESCRIPTION
This adds `Builder.add/2`, which accepts a single model element, or a
list of model elements.

This allows the capture of individual model elements in simpler forms,
which may then be subsequently added to the builder.