### PR TITLE
Remove DSL bare variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ The result of the `build` function is a `Model`.
 
     builder =
       Builder.new()
-      |> Builder.def_int_var(x, {0, 10})
-      |> Builder.def_int_var(y, {0, 10})
-      |> Builder.def_bool_var(b)
-      |> Builder.constrain(x >= 5, if: b)
-      |> Builder.constrain(x <= 5, unless: b)
-      |> Builder.constrain(x + y == 10, if: b)
-      |> Builder.constrain(y == 0, unless: b)
+      |> Builder.def_int_var("x", {0, 10})
+      |> Builder.def_int_var("y", {0, 10})
+      |> Builder.def_bool_var("b")
+      |> Builder.constrain("x" >= 5, if: "b")
+      |> Builder.constrain("x" <= 5, unless: "b")
+      |> Builder.constrain("x" + "y" == 10, if: "b")
+      |> Builder.constrain("y" == 0, unless: "b")
 
     {response, acc} =
       builder
@@ -102,22 +102,22 @@ The result of the `build` function is a `Model`.
 
 ### Variables
 
-Model variables are symbolic and don't leak to the surrounding Elixir context.
-This allows the variables to be consistently referenced through a builder
-pipeline, for example, without having to capture an intermediate result.
+Model variables are symbolic, represented as strings or atoms, and so don't
+interfere to the surrounding Elixir context. This allows the variables to be
+consistently referenced through a builder pipeline, for example, without having
+to capture an intermediate result.
 
-To reference an Elixir value from an Exhort expression, pin it like you would in
-Ecto using `^`.
+Elixir variables may be used "as is" in expressions, allowing variables to be
+generated from enumerable collections.
 
-In the following expression, `x` is a model variable, while `y` is an Elixir
+In the following expression, `"x"` is a model variable, while `y` is an Elixir
 variable:
 
 ```elixir
-x < ^y + 3
+"x" < y + 3
 ```
 
-Strings and atoms are also supported for variable names, which is often valuable
-when names are generated:
+Building variables is done through normal Elixir expressions:
 
 ```elixir
     builder
@@ -134,7 +134,7 @@ Of course, such names are still usable in expressions:
 
 ```elixir
     builder
-    |> Builder.constrain("slack_#{bin}" <= ^bin_total)
+    |> Builder.constrain("slack_#{bin}" <= bin_total)
 ```
 
 ### Expressions
@@ -150,7 +150,7 @@ comprehension.
       load_bin = "load_#{bin}"
 
       builder
-      |> Builder.constrain(sum(for {item, x} <- ^expr, do: ^item * ^x) == ^load_bin)
+      |> Builder.constrain(sum(for {item, x} <- expr, do: item * x) == load_bin)
     end)
 ```
 

--- a/lib/exhort/sat/builder.ex
+++ b/lib/exhort/sat/builder.ex
@@ -80,13 +80,8 @@ defmodule Exhort.SAT.Builder do
   @doc """
   Define a boolean variable in the model.
   """
-  defmacro def_bool_var(builder, name) do
-    name = DSL.transform_expression(name)
-
-    quote do
-      %Builder{vars: vars} = builder = unquote(builder)
-      %Builder{builder | vars: Vars.add(vars, %BoolVar{name: unquote(name)})}
-    end
+  def def_bool_var(%Builder{vars: vars} = builder, name) do
+    %Builder{builder | vars: Vars.add(vars, %BoolVar{name: name})}
   end
 
   @doc """
@@ -96,17 +91,8 @@ defmodule Exhort.SAT.Builder do
   - `domain` is the uppper and lower bounds of the integer as a tuple,
     `{lower_bound, upper_bound}`
   """
-  defmacro def_int_var(builder, name, domain) do
-    name = DSL.transform_expression(name)
-
-    quote do
-      %Builder{vars: vars} = builder = unquote(builder)
-
-      %Builder{
-        builder
-        | vars: Vars.add(vars, %IntVar{name: unquote(name), domain: unquote(domain)})
-      }
-    end
+  def def_int_var(%Builder{vars: vars} = builder, name, domain) do
+    %Builder{builder | vars: Vars.add(vars, %IntVar{name: name, domain: domain})}
   end
 
   @doc """
@@ -120,42 +106,24 @@ defmodule Exhort.SAT.Builder do
   - `stop` is the end of the interval
   """
 
-  defmacro def_interval_var(builder, name, start, size, stop) do
-    name = DSL.transform_expression(name)
-    start = DSL.transform_expression(start)
-    size = DSL.transform_expression(size)
-    stop = DSL.transform_expression(stop)
-
-    quote do
-      %Builder{vars: vars} = builder = unquote(builder)
-
-      %Builder{
-        builder
-        | vars:
-            Vars.add(vars, %IntervalVar{
-              name: unquote(name),
-              start: unquote(start),
-              size: unquote(size),
-              stop: unquote(stop)
-            })
-      }
-    end
+  def def_interval_var(%Builder{vars: vars} = builder, name, start, size, stop) do
+    %Builder{
+      builder
+      | vars:
+          Vars.add(vars, %IntervalVar{
+            name: name,
+            start: start,
+            size: size,
+            stop: stop
+          })
+    }
   end
 
   @doc """
   Create a named constant. `value` should be a constant integer.
   """
-  defmacro def_constant(builder, name, value) do
-    name = DSL.transform_expression(name)
-
-    quote do
-      %Builder{vars: vars} = builder = unquote(builder)
-
-      %Builder{
-        builder
-        | vars: Vars.add(vars, %IntVar{name: unquote(name), domain: unquote(value)})
-      }
-    end
+  def def_constant(%Builder{vars: vars} = builder, name, value) do
+    %Builder{builder | vars: Vars.add(vars, %IntVar{name: name, domain: value})}
   end
 
   @doc """

--- a/lib/exhort/sat/dsl.ex
+++ b/lib/exhort/sat/dsl.ex
@@ -45,7 +45,6 @@ defmodule Exhort.SAT.DSL do
   defp transform([head | []]), do: [transform(head)]
   defp transform([head | tail]), do: [transform(head) | transform(tail)]
 
-  defp transform({:^, _, [{_var, _, nil} = x]}), do: x
   defp transform({:if, x}), do: {:if, transform(x)}
   defp transform({:unless, x}), do: {:unless, transform(x)}
 
@@ -53,6 +52,5 @@ defmodule Exhort.SAT.DSL do
   defp transform({:<-, m, list}), do: {:<-, m, transform(list)}
   defp transform({:do, arg}), do: {:do, transform(arg)}
 
-  defp transform({x, _, _}), do: x
   defp transform(i), do: i
 end

--- a/lib/exhort/sat/int_var.ex
+++ b/lib/exhort/sat/int_var.ex
@@ -15,7 +15,10 @@ defmodule Exhort.SAT.IntVar do
   - `domain` - The upper and lower bounds of the variable defined as a tuple,
     `{lower_bound, upper_bound}`.
   """
-  @spec new(name :: String.t(), domain :: {lower_bound :: integer(), upper_bound :: integer()}) ::
+  @spec new(
+          name :: String.t(),
+          domain :: {lower_bound :: integer(), upper_bound :: integer()} | integer()
+        ) ::
           IntVar.t()
   def new(name, domain) do
     %IntVar{name: name, domain: domain}

--- a/lib/exhort/sat/solver_response.ex
+++ b/lib/exhort/sat/solver_response.ex
@@ -11,9 +11,9 @@ defmodule Exhort.SAT.SolverResponse do
   alias __MODULE__
   alias Exhort.NIF.Nif
   alias Exhort.SAT.BoolVar
-  alias Exhort.SAT.DSL
   alias Exhort.SAT.IntVar
   alias Exhort.SAT.Model
+  alias Exhort.SAT.SolverResponse
   alias Exhort.SAT.Vars
 
   @spec build(map(), Model.t()) :: SolverResponse.t()
@@ -50,25 +50,17 @@ defmodule Exhort.SAT.SolverResponse do
   @doc """
   Get the corresponding value of the integer variable.
   """
-  @spec int_val(Macro.t(), Macro.t()) :: Macro.t()
-  defmacro int_val(response_exp, var_exp) do
-    var_exp = DSL.transform_expression(var_exp)
-
-    quote do
-      SolverResponse.get_int_val(unquote(response_exp), unquote(var_exp))
-    end
+  @spec int_val(SolverResponse.t(), literal :: String.t() | atom()) :: integer()
+  def int_val(response, var) do
+    SolverResponse.get_int_val(response, var)
   end
 
   @doc """
   Get the corresponding value of the boolean variable.
   """
-  @spec bool_val(Macro.t(), literal :: atom() | String.t()) :: Macro.t()
-  defmacro bool_val(response_exp, var_exp) do
-    var_exp = DSL.transform_expression(var_exp)
-
-    quote do
-      SolverResponse.get_bool_val(unquote(response_exp), unquote(var_exp))
-    end
+  @spec bool_val(SolverResponse.t(), literal :: String.t() | atom()) :: integer()
+  def bool_val(response, var) do
+    SolverResponse.get_bool_val(response, var)
   end
 
   @spec get_int_val(SolverResponse.t(), var :: atom() | String.t() | IntVar.t()) ::

--- a/test/samples/exhort/sat/binpacking_problem_test.exs
+++ b/test/samples/exhort/sat/binpacking_problem_test.exs
@@ -38,7 +38,7 @@ defmodule Samples.Exhort.SAT.BinpackingProblem do
         expr = Enum.map(items, &{elem(&1, 0), "x_#{elem(&1, 0)}_#{bin}"})
         load_bin = "load_#{bin}"
 
-        Constraint.new(sum(for {item, x} <- ^expr, do: ^item * ^x) == ^load_bin)
+        Constraint.new(sum(for {item, x} <- expr, do: item * x) == load_bin)
       end)
 
     placements =
@@ -46,7 +46,7 @@ defmodule Samples.Exhort.SAT.BinpackingProblem do
       |> Enum.map(fn {item, num_copies} ->
         x_i = Enum.map(all_bins, &"x_#{item}_#{&1}")
 
-        Constraint.new(sum(^x_i) == ^num_copies)
+        Constraint.new(sum(x_i) == num_copies)
       end)
 
     constrain_load_to_slack =
@@ -58,8 +58,8 @@ defmodule Samples.Exhort.SAT.BinpackingProblem do
         slack_bin = "slack_#{bin}"
 
         [
-          Constraint.new(^load_bin <= ^safe_capacity, if: ^slack_bin),
-          Constraint.new(^load_bin > ^safe_capacity, unless: ^slack_bin)
+          Constraint.new(load_bin <= safe_capacity, if: slack_bin),
+          Constraint.new(load_bin > safe_capacity, unless: slack_bin)
         ]
       end)
       |> List.flatten()
@@ -74,7 +74,7 @@ defmodule Samples.Exhort.SAT.BinpackingProblem do
       |> Builder.add(constrain_load_to_slack)
       |> then(fn builder ->
         bins = Enum.map(all_bins, &"slack_#{&1}")
-        Builder.maximize(builder, sum(^bins))
+        Builder.maximize(builder, sum(bins))
       end)
 
     response =

--- a/test/samples/exhort/sat/cp_is_fun_test.exs
+++ b/test/samples/exhort/sat/cp_is_fun_test.exs
@@ -24,8 +24,8 @@ defmodule Samples.Exhort.SAT.CpIsFun do
 
       # CP + IS + FUN = TRUE
       |> Builder.constrain(
-        "c" * ^base + "p" + "i" * ^base + "s" + "f" * ^base * ^base + "u" * ^base + "n" ==
-          "t" * ^base * ^base * ^base + "r" * ^base * ^base + "u" * ^base + "e"
+        "c" * base + "p" + "i" * base + "s" + "f" * base * base + "u" * base + "n" ==
+          "t" * base * base * base + "r" * base * base + "u" * base + "e"
       )
 
     solution_callback = fn %SolverResponse{} = _response, acc ->

--- a/test/samples/exhort/sat/minimal_job_shop_test.exs
+++ b/test/samples/exhort/sat/minimal_job_shop_test.exs
@@ -100,7 +100,7 @@ defmodule Samples.Exhort.SAT.MinimalJobShop do
         |> Enum.map(fn {task_id, _task} ->
           task_start = tasks[{job_id, task_id + 1}].start
           task_end = tasks[{job_id, task_id}].end
-          Constraint.new(^task_start >= ^task_end)
+          Constraint.new(task_start >= task_end)
         end)
       end)
       |> List.flatten()
@@ -140,8 +140,8 @@ defmodule Samples.Exhort.SAT.MinimalJobShop do
                  "Machine: #{machine_id}",
                  {
                    "#{job_id}_#{task_id}",
-                   SolverResponse.int_val(response, ^start_var),
-                   SolverResponse.int_val(response, ^end_var)
+                   SolverResponse.int_val(response, start_var),
+                   SolverResponse.int_val(response, end_var)
                  }
                }
              end)

--- a/test/samples/exhort/sat/multiple_knapsack_test.exs
+++ b/test/samples/exhort/sat/multiple_knapsack_test.exs
@@ -41,7 +41,7 @@ defmodule Samples.Exhort.SAT.MultipleKnapsack do
         x_option_vars = Enum.map(x_options, fn {i, b} -> "x_#{i}_#{b}" end)
 
         total_x = LinearExpression.sum(x_option_vars)
-        Builder.constrain(builder, ^total_x <= 1)
+        Builder.constrain(builder, total_x <= 1)
       end)
 
     builder =
@@ -55,7 +55,7 @@ defmodule Samples.Exhort.SAT.MultipleKnapsack do
 
         total_bin_weight = LinearExpression.sum(bin_weight)
         bin_capacity = Enum.at(bin_capacities, bin)
-        Builder.constrain(builder, ^total_bin_weight <= ^bin_capacity)
+        Builder.constrain(builder, total_bin_weight <= bin_capacity)
       end)
 
     builder =
@@ -66,7 +66,7 @@ defmodule Samples.Exhort.SAT.MultipleKnapsack do
         end)
       end)
       |> then(fn list ->
-        Builder.maximize(builder, sum(^list))
+        Builder.maximize(builder, sum(list))
       end)
 
     solver =

--- a/test/samples/exhort/sat/n_queens_test.exs
+++ b/test/samples/exhort/sat/n_queens_test.exs
@@ -21,7 +21,7 @@ defmodule Samples.Exhort.SAT.NQueens do
 
         builder =
           builder
-          |> Builder.def_int_var(^queen, {0, board_size - 1})
+          |> Builder.def_int_var(queen, {0, board_size - 1})
           |> Builder.def_constant("#{column}", column)
 
         %{acc | builder: builder, queens: queens}

--- a/test/samples/exhort/sat/no_overlap_test.exs
+++ b/test/samples/exhort/sat/no_overlap_test.exs
@@ -42,9 +42,9 @@ defmodule Samples.Exhort.SAT.NoOverlap do
         "weekend_2"
       ])
       |> Builder.def_int_var("makespan", {0, horizon})
-      |> Builder.constrain("end_0", :<=, "makespan")
-      |> Builder.constrain("end_1", :<=, "makespan")
-      |> Builder.constrain("end_2", :<=, "makespan")
+      |> Builder.constrain("end_0" <= "makespan")
+      |> Builder.constrain("end_1" <= "makespan")
+      |> Builder.constrain("end_2" <= "makespan")
       |> Builder.minimize("makespan")
       |> Builder.build()
       |> Model.solve()

--- a/test/samples/exhort/sat/nurse_scheduling_test.exs
+++ b/test/samples/exhort/sat/nurse_scheduling_test.exs
@@ -95,7 +95,7 @@ defmodule Samples.Exhort.SAT.NurseScheduling do
         end)
       end)
       |> then(fn list ->
-        Builder.maximize(builder, sum(^list))
+        Builder.maximize(builder, sum(list))
       end)
 
     solver =

--- a/test/samples/exhort/sat/rabbits_and_pheasants_test.exs
+++ b/test/samples/exhort/sat/rabbits_and_pheasants_test.exs
@@ -5,15 +5,15 @@ defmodule Samples.Exhort.SAT.RabbitsAndPheasantsTest do
   test "rabbits and pheasants" do
     response =
       Builder.new()
-      |> Builder.def_int_var(r, {0, 100})
-      |> Builder.def_int_var(p, {0, 100})
-      |> Builder.constrain(r + p == 20)
-      |> Builder.constrain(4 * r + 2 * p == 56)
+      |> Builder.def_int_var("r", {0, 100})
+      |> Builder.def_int_var("p", {0, 100})
+      |> Builder.constrain("r" + "p" == 20)
+      |> Builder.constrain(4 * "r" + 2 * "p" == 56)
       |> Builder.build()
       |> Model.solve()
 
     assert :optimal = response.status
-    assert 8 == SolverResponse.int_val(response, r)
-    assert 12 == SolverResponse.int_val(response, p)
+    assert 8 == SolverResponse.int_val(response, "r")
+    assert 12 == SolverResponse.int_val(response, "p")
   end
 end

--- a/test/samples/exhort/sat/simple_sat_test.exs
+++ b/test/samples/exhort/sat/simple_sat_test.exs
@@ -5,15 +5,15 @@ defmodule Samples.Exhort.SAT.SimpleSAT do
   test "simple sat program" do
     model =
       Builder.new()
-      |> Builder.def_int_var(x, {0, 2})
-      |> Builder.def_int_var(y, {0, 2})
-      |> Builder.def_int_var(z, {0, 2})
-      |> Builder.constrain(x != y)
+      |> Builder.def_int_var("x", {0, 2})
+      |> Builder.def_int_var("y", {0, 2})
+      |> Builder.def_int_var("z", {0, 2})
+      |> Builder.constrain("x" != "y")
       |> Builder.build()
 
     response = Model.solve(model)
-    assert 1 == SolverResponse.int_val(response, x)
-    assert 0 == SolverResponse.int_val(response, y)
-    assert 0 == SolverResponse.int_val(response, z)
+    assert 1 == SolverResponse.int_val(response, "x")
+    assert 0 == SolverResponse.int_val(response, "y")
+    assert 0 == SolverResponse.int_val(response, "z")
   end
 end

--- a/test/samples/exhort/sat/zebra_test.exs
+++ b/test/samples/exhort/sat/zebra_test.exs
@@ -83,11 +83,11 @@ defmodule Samples.Exhort.SAT.Zebra do
     people = ["englishman", "spaniard", "japanese", "ukrainian", "norwegian"]
 
     assert Enum.find(people, fn p ->
-             SolverResponse.int_val(response, ^p) == SolverResponse.int_val(response, "water")
+             SolverResponse.int_val(response, p) == SolverResponse.int_val(response, "water")
            end)
 
     assert Enum.find(people, fn p ->
-             SolverResponse.int_val(response, ^p) == SolverResponse.int_val(response, "zebra")
+             SolverResponse.int_val(response, p) == SolverResponse.int_val(response, "zebra")
            end)
   end
 end


### PR DESCRIPTION
This removes support for bare variables in the DSL.

Most variables will be generated, which previously required the use of
the pin operator to escape them to Elixir.

Now variables must be strings or atoms, which means Elixir variables are
simpler and more intuitive to use.