### PR TITLE
Add single module for creating expressions

### DIFF
--- a/lib/exhort/sat/builder.ex
+++ b/lib/exhort/sat/builder.ex
@@ -29,6 +29,7 @@ defmodule Exhort.SAT.Builder do
       alias Exhort.SAT.BoolVar
       alias Exhort.SAT.Builder
       alias Exhort.SAT.Constraint
+      alias Exhort.SAT.Expr
       alias Exhort.SAT.IntervalVar
       alias Exhort.SAT.IntVar
       alias Exhort.SAT.LinearExpression
@@ -37,6 +38,7 @@ defmodule Exhort.SAT.Builder do
 
       require Exhort.SAT.Builder
       require Exhort.SAT.Constraint
+      require Exhort.SAT.Expr
       require Exhort.SAT.LinearExpression
       require Exhort.SAT.SolverResponse
     end

--- a/lib/exhort/sat/expr.ex
+++ b/lib/exhort/sat/expr.ex
@@ -1,0 +1,43 @@
+defmodule Exhort.SAT.Expr do
+  @moduledoc """
+  Create an expression in the expression language.
+
+  If the expression contains a comparison operator, it will be a constraint.
+  Otherwise, it will be a linear expression.
+  """
+
+  alias Exhort.SAT.DSL
+  alias Exhort.SAT.Constraint
+
+  @comparison [:<, :<=, :==, :>=, :>, :"abs=="]
+
+  defmacro new(expr, opts \\ [])
+
+  defmacro new({op, _, [_lhs, _rhs]} = expr, opts) when op in @comparison do
+    expr =
+      case expr do
+        {:==, m1, [lhs, {:abs, _m2, [var]}]} ->
+          {:"abs==", m1, [lhs, var]}
+
+        expr ->
+          expr
+      end
+
+    {op, _, [lhs, rhs]} = expr
+    lhs = DSL.transform_expression(lhs)
+    rhs = DSL.transform_expression(rhs)
+    opts = Enum.map(opts, &DSL.transform_expression(&1))
+
+    quote do
+      %Constraint{defn: {unquote(lhs), unquote(op), unquote(rhs), unquote(opts)}}
+    end
+  end
+
+  defmacro new(expr, _opts) do
+    expr = DSL.transform_expression(expr)
+
+    quote do
+      unquote(expr)
+    end
+  end
+end


### PR DESCRIPTION
This adds the `Exhort.SAT.Expr` module, which includes a macro for
generating either constraints or linear expressions.

This presents the user from having to know what kind of expression to
create.

To demonstrate, used it and the `Builder.add` to refactor the queens
sample.