### PR TITLE
Support compilation on Debian

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,11 @@ all: nifs
 
 nifs: priv/lib/nif.so
 
-ifeq ($(ORTOOLS),)
-	ORTOOLS=/usr/local
-endif
+ORTOOLS ?= /usr/local
+ERLANG_HOME ?= /usr/local
 
-ifeq ($(ERLANG_HOME),)
-	ERLANG_HOME=/usr/local
-endif
-
-INCLUDES=-I $(ERLANG_HOME)/usr/include -I $(ORTOOLS)/include
-LIBPATH=-L $(ERLANG_HOME)/usr/lib -L $(ORTOOLS)/lib
+INCLUDES=-I$(ERLANG_HOME)/usr/include -I$(ORTOOLS)/include
+LIBPATH=-L$(ERLANG_HOME)/usr/lib -L$(ORTOOLS)/lib
 CFLAGS=-std=c++17
 LIBS=-lortools -labsl_raw_hash_set -labsl_base
 SRC=$(wildcard c_src/*.cc)

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@ all: nifs
 
 nifs: priv/lib/nif.so
 
-# ifeq ($(ORTOOLS),)
-# 	ORTOOLS=/usr/local
-# endif
+ifeq ($(ORTOOLS),)
+	ORTOOLS=/usr/local
+endif
 
-# ifeq ($(ERLANG_HOME),)
-# 	ERLANG_HOME=/usr/local
-# endif
+ifeq ($(ERLANG_HOME),)
+	ERLANG_HOME=/usr/local
+endif
 
 INCLUDES=-I $(ERLANG_HOME)/usr/include -I $(ORTOOLS)/include
 LIBPATH=-L $(ERLANG_HOME)/usr/lib -L $(ORTOOLS)/lib

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@ all: nifs
 
 nifs: priv/lib/nif.so
 
-ifeq ($(ORTOOLS),)
-	ORTOOLS=/usr/local
-endif
+# ifeq ($(ORTOOLS),)
+# 	ORTOOLS=/usr/local
+# endif
 
-ifeq ($(ERLANG_HOME),)
-	ERLANG_HOME=/usr/local
-endif
+# ifeq ($(ERLANG_HOME),)
+# 	ERLANG_HOME=/usr/local
+# endif
 
 INCLUDES=-I $(ERLANG_HOME)/usr/include -I $(ORTOOLS)/include
 LIBPATH=-L $(ERLANG_HOME)/usr/lib -L $(ORTOOLS)/lib

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,33 @@
 
 all: nifs
 
-
 nifs: priv/lib/nif.so
 
-INCLUDES=-I ~/.asdf/installs/erlang/24.1.7/usr/include
+ifeq ($(ORTOOLS),)
+	ORTOOLS=/usr/local
+endif
+
+ifeq ($(ERLANG_HOME),)
+	ERLANG_HOME=/usr/local
+endif
+
+INCLUDES=-I $(ERLANG_HOME)/usr/include -I $(ORTOOLS)/include
+LIBPATH=-L $(ERLANG_HOME)/usr/lib -L $(ORTOOLS)/lib
 CFLAGS=-std=c++17
-SOFLAGS=-dynamiclib -undefined dynamic_lookup -fPIC
-LIBS=-lortools -labsl_base
+LIBS=-lortools -labsl_raw_hash_set -labsl_base
 SRC=$(wildcard c_src/*.cc)
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+	SOFLAGS=-fPIC -shared -Wl,-rpath=$(ORTOOLS)/lib -Wl,-rpath=$(ERLANG_HOME)/usr/lib
+endif
+ifeq ($(UNAME_S),Darwin)
+	SOFLAGS=-dynamiclib -undefined dynamic_lookup -fPIC
+endif
 
 priv/lib/nif.so: $(SRC)
 	@mkdir -p $(@D)
-	clang++ $(INCLUDES) $(CFLAGS) $(SOFLAGS) $(LIBS) -o priv/lib/nif.so $(SRC)
+	$(CC) $(INCLUDES) $(CFLAGS) $(SOFLAGS) -o priv/lib/nif.so $(SRC) $(LIBPATH) $(LIBS)
 
 clean:
-	rm priv/lib/*.so
+	rm -f priv/lib/*.so

--- a/README.md
+++ b/README.md
@@ -44,17 +44,27 @@ Next, install the or-tools from Homebrew:
 brew install or-tools
 ```
 
-Then:
+Finally, leverage `asdf` for the required versions of Elixir and Elang:
 
 ```sh
-mix deps.get
-mix compile
-mix test
+asdf install
 ```
+
+Then export the locations of Erlang and the OR Tools:
+
+```sh
+export ERLANG_HOME=$HOME/.asdf/installs/erlang/24.2.1
+export ORTOOLS=/usr/local/lib
+```
+
 
 ### Debian
 
-Follow the instructions [here](https://developers.google.com/optimization/install/cpp/linux) and install from the appropriate archive. You will likely want to install them in a reasonable place like `/usr/local/lib` and perhaps link them to a consistent place.
+Follow the instructions
+[here](https://developers.google.com/optimization/install/cpp/linux) and install
+from the appropriate archive. You will likely want to install them in a
+reasonable place like `/usr/local/lib` and perhaps link them to a consistent
+place.
 
 For example:
 
@@ -64,18 +74,23 @@ tar xf or-tools_amd64_debian-11_v9.2.9972.tar.gz -C /usr/local/lib
 ln -s /usr/local/lib/or-tools_Debian-11-64bit_v9.2.9972 /usr/local/lib/ortools
 ```
 
+Then export the locations of Erlang and the OR Tools:
+
+```sh
+export ERLANG_HOME=/usr/local/lib/erlang
+export ORTOOLS=/usr/local/lib/ortools
+```
+
 ### Compiling
 
 Exhort uses NIFs for intrfacing with the Google OR tools. This means that Exhort
 NIFs must be compiled using a C compiler and Make. The `Makefile` contains these
 instructions. It just needs to know where you have installed both Erlang and the
-Google OR Tools. The `Makefile` will use `ERLANG_HOME` for the Erlang
-installation and `ORTOOLS` for the Google OR Tools.
+Google OR Tools. It will use the environment variables you exported above.
 
-```
-export ERLANG_HOME=/usr/local/lib/erlang
-export ORTOOLS=/usr/local/lib/ortools
+```sh
 mix compile
+mix test
 ```
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -52,6 +52,32 @@ mix compile
 mix test
 ```
 
+### Debian
+
+Follow the instructions [here](https://developers.google.com/optimization/install/cpp/linux) and install from the appropriate archive. You will likely want to install them in a reasonable place like `/usr/local/lib` and perhaps link them to a consistent place.
+
+For example:
+
+```sh
+wget https://github.com/google/or-tools/releases/download/v9.2/or-tools_amd64_debian-11_v9.2.9972.tar.gz
+tar xf or-tools_amd64_debian-11_v9.2.9972.tar.gz -C /usr/local/lib
+ln -s /usr/local/lib/or-tools_Debian-11-64bit_v9.2.9972 /usr/local/lib/ortools
+```
+
+### Compiling
+
+Exhort uses NIFs for intrfacing with the Google OR tools. This means that Exhort
+NIFs must be compiled using a C compiler and Make. The `Makefile` contains these
+instructions. It just needs to know where you have installed both Erlang and the
+Google OR Tools. The `Makefile` will use `ERLANG_HOME` for the Erlang
+installation and `ORTOOLS` for the Google OR Tools.
+
+```
+export ERLANG_HOME=/usr/local/lib/erlang
+export ORTOOLS=/usr/local/ortools
+mix compile
+```
+
 ## Getting Started
 
 The easiest way to get started is with the sample Livebook notebooks in the

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ installation and `ORTOOLS` for the Google OR Tools.
 
 ```
 export ERLANG_HOME=/usr/local/lib/erlang
-export ORTOOLS=/usr/local/ortools
+export ORTOOLS=/usr/local/lib/ortools
 mix compile
 ```
 

--- a/c_src/cp_model_builder.cc
+++ b/c_src/cp_model_builder.cc
@@ -2,7 +2,6 @@
 #include <iostream>
 #include "erl_nif.h"
 #include "ortools/sat/cp_model.h"
-#include "absl/types/span.h"
 #include "wrappers.h"
 #include "linear_expression.h"
 #include "bool_var.h"
@@ -1051,8 +1050,7 @@ extern "C"
     model.Add(NewFeasibleSolutionObserver([&](const CpSolverResponse &r)
                                           {
                                             ERL_NIF_TERM term = make_cp_solver_response(env, r);
-                                            enif_send(env, &pid, NULL, term);
-                                          }));
+                                            enif_send(env, &pid, NULL, term); }));
 
     CpSolverResponse response = SolveCpModel(builder_wrapper->p->Build(), &model);
     return make_cp_solver_response(env, response);

--- a/c_src/cp_solver_response.cc
+++ b/c_src/cp_solver_response.cc
@@ -43,27 +43,27 @@ extern "C"
     vector<ERL_NIF_TERM> values;
 
     const char *res_key = "res";
-    ErlNifBinary res = {.data = (unsigned char *)res_key, .size = strlen(res_key)};
+    ErlNifBinary res = {.size = strlen(res_key), .data = (unsigned char *)res_key};
     keys.push_back(enif_make_binary(env, &res));
     values.push_back(term);
 
     const char *status_key = "status";
-    ErlNifBinary status = {.data = (unsigned char *)status_key, .size = strlen(status_key)};
+    ErlNifBinary status = {.size = strlen(status_key), .data = (unsigned char *)status_key};
     keys.push_back(enif_make_binary(env, &status));
     values.push_back(enif_make_int(env, from.status()));
 
     const char *objective_key = "objective";
-    ErlNifBinary objective = {.data = (unsigned char *)objective_key, .size = strlen(objective_key)};
+    ErlNifBinary objective = {.size = strlen(objective_key), .data = (unsigned char *)objective_key};
     keys.push_back(enif_make_binary(env, &objective));
     values.push_back(enif_make_double(env, from.objective_value()));
 
     const char *walltime_key = "walltime";
-    ErlNifBinary walltime = {.data = (unsigned char *)walltime_key, .size = strlen(walltime_key)};
+    ErlNifBinary walltime = {.size = strlen(walltime_key), .data = (unsigned char *)walltime_key};
     keys.push_back(enif_make_binary(env, &walltime));
     values.push_back(enif_make_double(env, from.wall_time()));
 
     const char *usertime_key = "usertime";
-    ErlNifBinary usertime = {.data = (unsigned char *)usertime_key, .size = strlen(usertime_key)};
+    ErlNifBinary usertime = {.size = strlen(usertime_key), .data = (unsigned char *)usertime_key};
     keys.push_back(enif_make_binary(env, &usertime));
     values.push_back(enif_make_double(env, from.user_time()));
 

--- a/c_src/linear_expression.cc
+++ b/c_src/linear_expression.cc
@@ -1,14 +1,11 @@
 #include <cstring>
 #include "erl_nif.h"
 #include "ortools/sat/cp_model.h"
-#include "absl/types/span.h"
 #include "wrappers.h"
 #include "bool_var.h"
 #include "int_var.h"
 #include "utility.h"
 
-using absl::MakeSpan;
-using absl::Span;
 using operations_research::Domain;
 using operations_research::sat::LinearExpr;
 


### PR DESCRIPTION
This updates the `Makefile` so that it supports compiling on a Linux
system, Debian specifically.

It also adds support for `ERLANG_HOME` and `ORTOOLS` as vairables
determining the location of depdendencies.